### PR TITLE
Flush after writing image.

### DIFF
--- a/src/javase/java/com/luciad/imageio/webp/WebPWriter.java
+++ b/src/javase/java/com/luciad/imageio/webp/WebPWriter.java
@@ -71,6 +71,7 @@ class WebPWriter extends ImageWriter {
 
     byte[] encodedData = encode(writeParam.getEncoderOptions(), ri);
     output.write(encodedData);
+    output.flush();
   }
 
   private static byte[] encode(WebPEncoderOptions aOptions, RenderedImage aImage) throws IOException


### PR DESCRIPTION
Other ImageIO writers do this, eg JPEGImageWriter. Without the flush, when using something like a javax.imageio.stream.MemoryCacheImageOutputStream, the cached data is never written to the underlying stream like it is with all other JRE writers.